### PR TITLE
Don't use `Expect` header and components in meta section

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ An example API URL: `https://yournode.org/v1/search`
 
 ## Expectations
 
-A request may specify which API version response they require (if any) in the format of an [X-Range](https://docs.npmjs.com/misc/semver#x-ranges-12x-1x-12-) string (The Major version MUST match) using the `Expect` header of the request. The server must either respond with a backwards compatible version of the response, or respond with HTTP Status Code `417 Expectation Failed`.
+A request may specify which API version response they require (if any) in the format of an [X-Range](https://docs.npmjs.com/misc/semver#x-ranges-12x-1x-12-) string (The Major version MUST match) using a header of `X-GA4GH-Discovery-Expect` with the request. The server must either respond with a backwards compatible version of the response, or respond with HTTP Status Code `400`, with a text body detailing the unsupported version request, which should include which versions are supported.
 
 If a request does not specify a required response version, the responding server must respond with the latest version they support of the major version defined in the API URL.
 

--- a/json_schema/schemas_source/request.yaml
+++ b/json_schema/schemas_source/request.yaml
@@ -1,6 +1,12 @@
 ---
 "$id": http://ga4gh.org/schemas/discovery/search/request
 "$schema": http://json-schema.org/draft-07/schema#
+definitions:
+  component-version:
+    description: An object where a key is the component name and the value specifies the version that was provided
+    type: object
+    additionalProperties:
+      "$ref": http://ga4gh.org/schemas/discovery/search/definitions#definitions/semver
 type: object
 required:
   - query
@@ -17,15 +23,15 @@ properties:
         description: Contains metadata relating to the request
         type: object
         properties:
-          components:
-            description: An object where a key is the component name and the value specifies the version that was provided
-            type: object
-            additionalProperties:
-              "$ref": http://ga4gh.org/schemas/discovery/search/definitionst#definitions/semver
+          searchComponents:
+            "$ref": "#/definitions/component-version"
+          requestMetaComponents:
+            "$ref": "#/definitions/component-version"
       apiVersion:
         description: The full version of the API being used in the request.
         "$ref": http://ga4gh.org/schemas/discovery/search/definitionst#definitions/semver
       components:
+        description: Request meta components
         "$ref": http://ga4gh.org/schemas/discovery/search/components/request_meta_components
   requires:
     type: object
@@ -46,6 +52,7 @@ properties:
       - components
     properties:
       components:
+        description: Search components
         "$ref": http://ga4gh.org/schemas/discovery/search/components/search_components
   logic:
     "$ref": http://ga4gh.org/schemas/discovery/search/boolean_logic

--- a/json_schema/schemas_source/request.yaml
+++ b/json_schema/schemas_source/request.yaml
@@ -7,6 +7,18 @@ definitions:
     type: object
     additionalProperties:
       "$ref": http://ga4gh.org/schemas/discovery/search/definitions#definitions/semver
+  components-in-request:
+    description: An object which has component types that can be used in a request
+    type: object
+    propertyNames:
+      enum:
+        - search
+        - requestMeta
+    additionalProperties:
+      "$ref": "#/definitions/component-version"
+    "$comment": |
+      `propertyNames` makes sure that all the properties of this object have one of the allowed names.
+      Combining this with `additionalProperties` which uses a reference means all property values have the same validation constraint
 type: object
 required:
   - query
@@ -23,10 +35,8 @@ properties:
         description: Contains metadata relating to the request
         type: object
         properties:
-          searchComponents:
-            "$ref": "#/definitions/component-version"
-          requestMetaComponents:
-            "$ref": "#/definitions/component-version"
+          components:
+            "$ref": "#/definitions/components-in-request"
       apiVersion:
         description: The full version of the API being used in the request.
         "$ref": http://ga4gh.org/schemas/discovery/search/definitionst#definitions/semver

--- a/json_schema/schemas_source/response.yaml
+++ b/json_schema/schemas_source/response.yaml
@@ -24,9 +24,13 @@ properties:
         required:
           - apiVersion
         properties:
-          components:
+          recordComponents:
+            "$ref": "#/definitions/component-version"
+          recordMetaComponents:
             "$ref": "#/definitions/component-version"
           collectionComponents:
+            "$ref": "#/definitions/component-version"
+          responseMetaComponents:
             "$ref": "#/definitions/component-version"
           apiVersion:
             description: The full version of the API that is being used for the response.

--- a/json_schema/schemas_source/response.yaml
+++ b/json_schema/schemas_source/response.yaml
@@ -7,6 +7,20 @@ definitions:
     type: object
     additionalProperties:
       "$ref": http://ga4gh.org/schemas/discovery/search/definitions#definitions/semver
+  components-in-response:
+    description: An object which has component types that can be used in a response
+    type: object
+    propertyNames:
+      enum:
+        - record
+        - recordMeta
+        - collection
+        - responseMeta
+    additionalProperties:
+      "$ref": "#/definitions/component-version"
+    "$comment": |
+      `propertyNames` makes sure that all the properties of this object have one of the allowed names.
+      Combining this with `additionalProperties` which uses a reference means all property values have the same validation constraint
 type: object
 required:
   - meta
@@ -24,14 +38,8 @@ properties:
         required:
           - apiVersion
         properties:
-          recordComponents:
-            "$ref": "#/definitions/component-version"
-          recordMetaComponents:
-            "$ref": "#/definitions/component-version"
-          collectionComponents:
-            "$ref": "#/definitions/component-version"
-          responseMetaComponents:
-            "$ref": "#/definitions/component-version"
+          components:
+            "$ref": "#/definitions/components-in-response"
           apiVersion:
             description: The full version of the API that is being used for the response.
             "$ref": http://ga4gh.org/schemas/discovery/search/definitionst#definitions/semver

--- a/result_structure/README.md
+++ b/result_structure/README.md
@@ -15,9 +15,11 @@ The search response to a valid search request which the server is able to proces
   "meta": {
     "response": {
       "apiVersion": "1.0.0",
-      "collectionComponents": {
+      "components": {
+        "collection": {
         "exists": "1.0.0",
         "count": "1.0.0"
+        }
       }
     },
     "request": {
@@ -57,6 +59,10 @@ The `meta` object allows the server to tell the client information about the res
 The `meta` object contains a `response`, `request`, and `components` object.
 
 The `meta` object is required.
+
+The `response` object in the `meta` object provides version information about the components used in the response.
+Each key is one of the component types found in a response (`record`, `recordMeta`, `collection`, or `responseMeta`).
+The values of these keys are objecets where the keys are component names and the values are the component data.
 
 #### `response`
 

--- a/search_structure/README.md
+++ b/search_structure/README.md
@@ -15,25 +15,25 @@ An `HTTP POST` request to `<base_remote_url>/search`, with an `application/json`
 
 ```javascript
 {
-    "meta": {
-        "request": {
-            "components": {
-                "search": {
-                    "gene": "1.0.0"
-                }
-            }
-        },
-        "apiVersion": "1.0.0"
-    },
-    "query": {
-        "components": {
-            "gene": [
-                {
-                    "ensemblID": "ENSG00000139618"
-                }
-            ]
+  "meta": {
+    "request": {
+      "components": {
+        "search": {
+          "gene": "1.0.0"
         }
+      }
+    },
+    "apiVersion": "1.0.0"
+  },
+  "query": {
+    "components": {
+      "gene": [
+        {
+          "ensemblID": "ENSG00000139618"
+        }
+      ]
     }
+  }
 }
 ```
 
@@ -66,64 +66,64 @@ The `query` object is required.
 
 ```javascript
 {
-    "meta": {
-        "request": {
-            "components": {
-                "search": {
-                    "gene": "1.0.0",
-                    "subjectVariant": "1.0.0",
-                    "phenotype": "1.0.0"
-                },
-                "requestMeta": {
-                  "queryIdentification": "1.0.0"
-                }
-            }
+  "meta": {
+    "request": {
+      "components": {
+        "search": {
+          "gene": "1.0.0",
+          "subjectVariant": "1.0.0",
+          "phenotype": "1.0.0"
         },
-        "apiVersion": "1.0.0",
-        "components": {
-            "queryIdentification" : {
-                "queryID" : "abc123",
-                "queryLabel" : "Search from client X for user on [date]"
-            }
+        "requestMeta": {
+          "queryIdentification": "1.0.0"
         }
+      }
     },
-
-    "requires": {
-        "response": {
-            "components": {
-                "exists": "1",
-                "count": "1"
-            }
-        }
-    },
-
-    "query": {
-        "components": {
-            "gene": [{
-                    "ensemblID": "ENSG00000139618",
-                    "hgncName": "BRCA2"
-                }],
-            "subjectVariant": [{
-                    "referenceName": "13",
-                    "start": 32936732,
-                    "referenceBases": "G",
-                    "alternateBases": "C",
-                    "assemblyID": "GRCh37"
-                }],
-            "phenotype": [{
-                    "id": "HP:0000765",
-                    "observation": "no",
-                    "label": "Abnormality of the thorax"
-                }]
-        }
-    },
-    "logic": {
-        "-AND": [
-            "/query/components/gene/0",
-            "/query/components/subjectVariant/0",
-            "/query/components/phenotype/0"
-        ]
+    "apiVersion": "1.0.0",
+    "components": {
+      "queryIdentification" : {
+        "queryID" : "abc123",
+        "queryLabel" : "Search from client X for user on [date]"
+      }
     }
+  },
+
+  "requires": {
+    "response": {
+      "components": {
+        "exists": "1",
+        "count": "1"
+      }
+    }
+  },
+
+  "query": {
+    "components": {
+      "gene": [{
+          "ensemblID": "ENSG00000139618",
+          "hgncName": "BRCA2"
+        }],
+      "subjectVariant": [{
+          "referenceName": "13",
+          "start": 32936732,
+          "referenceBases": "G",
+          "alternateBases": "C",
+          "assemblyID": "GRCh37"
+        }],
+      "phenotype": [{
+          "id": "HP:0000765",
+          "observation": "no",
+          "label": "Abnormality of the thorax"
+      }]
+    }
+  },
+  "logic": {
+    "-AND": [
+      "/query/components/gene/0",
+      "/query/components/subjectVariant/0",
+      "/query/components/phenotype/0"
+    ]
+  }
 }
 ```
 

--- a/search_structure/README.md
+++ b/search_structure/README.md
@@ -18,17 +18,20 @@ An `HTTP POST` request to `<base_remote_url>/search`, with an `application/json`
     "meta": {
         "request": {
             "components": {
-                "gene": "1.0.0",
+                "search": {
+                    "gene": "1.0.0"
+                }
             }
         },
         "apiVersion": "1.0.0"
     },
-
     "query": {
         "components": {
-            "gene": [{
-                    "ensemblID": "ENSG00000139618",
-                }],
+            "gene": [
+                {
+                    "ensemblID": "ENSG00000139618"
+                }
+            ]
         }
     }
 }
@@ -45,8 +48,7 @@ The `meta` object allows the client to tell the server information about the req
 
 The `apiVersion` property defines a string which represents the Search API version format being used.
 
-The `request` object contains a `components` object, where each key represents a component name, where the value is the version of the component used in the request.
-This includes components in the `query` and any `meta` components used, if any.
+The `request` object contains a `components` object. This is further explained in the more advanced query below.
 
 The `meta` object is required.
 
@@ -67,10 +69,14 @@ The `query` object is required.
     "meta": {
         "request": {
             "components": {
-                "gene": "1.0.0",
-                "subjectVariant": "1.0.0",
-                "phenotype": "1.0.0",
-                "queryIdentification": "1.0.0"
+                "search": {
+                    "gene": "1.0.0",
+                    "subjectVariant": "1.0.0",
+                    "phenotype": "1.0.0"
+                },
+                "requestMeta": {
+                  "queryIdentification": "1.0.0"
+                }
             }
         },
         "apiVersion": "1.0.0",
@@ -129,6 +135,9 @@ The `meta` object includes a `components` object, where the keys are component n
 These are Request Meta components, and allow the client to express things to the server about the request.
 In this example, the client has idenitifed this query by an ID which the server may reference.
 
+The `request` object in the `meta` object provides version information about the components used in the request.
+Each key is one of the component types found in a request (`search` or `requestMeta`).
+The values of these keys are objecets where the keys are component names and the values are the component data.
 
 ### Requires object
 


### PR DESCRIPTION
Use a different custom HTTP header to define the version range the client wants to receive.

Specify a different HTTP status code for an error response.

Fixes https://github.com/ga4gh-discovery/ga4gh-discovery-search/issues/47